### PR TITLE
Bugfix: no explicit ancestor

### DIFF
--- a/src/ProfilingTools.py
+++ b/src/ProfilingTools.py
@@ -126,6 +126,8 @@ class Profile(object):
 							ancestor = tax_path[i]
 							_data[tax_id]["branch_length"] += 1
 							i -= 1
+							if i+len(tax_path) < 0: # no ancestor available, manually set to -1 (the root)
+								ancestor = "-1"
 						_data[tax_id]["ancestor"] = ancestor
 				# Create a placeholder descendant key initialized to [], just so each tax_id has a descendant key associated to it
 				if "descendants" not in _data[tax_id]:  # if this tax_id doesn't have a descendant list,


### PR DESCRIPTION
Previously, `ProfilingTools.py` threw an IndexError: list index out of range for *e.g.*
```
32644.1 strain  ||||||32644|32644.1     ||||||unidentified|unidentified strain  0.0487  Sample9_65      p2
```
(Example taken from the CAMI GoldStandard, low. Similar entries for some plasmids.)

If the top level is reached and no ancestor found, I manually set the ancestor to `-1`.